### PR TITLE
feat: add a new stochastic synonyms layer for randomized text outputs.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,8 +52,8 @@ net = [
     "duckduckgo",
     "tokio",
 ]
-python = ["pyo3", "cli"]
-node = ["napi", "napi-derive", "napi-build", "cli"]
+python = ["pyo3", "cli", "net"]
+node = ["napi", "napi-derive", "napi-build", "cli", "net"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ flowchart TD
 - 🧩 **Neural Operators**: circular convolution with SGD kernel learning, Fourier spectral operators.
 - 🔤 **Text ↔ Equation**: encode any text into a symbolic equation; decode it back exactly (lossless via residuals).
 - 🔮 **Symbolic Prediction**: LMM-native text continuation via sliding-window GP regression and vocabulary anchoring.
+- 🎲 **Stochastic Enhancement**: synonym-bank word replacement (`--stochastic`) produces unique output every run while preserving mathematical sentence structure.
 
 ## 📦 Installation
 
@@ -160,6 +161,10 @@ Commands:
   ask            Ask a question and get an equation-scored answer from the web
   imagen         Generate an image from text via Spectral Field Synthesis
   help           Print this message or the help of the given subcommand(s)
+
+Global Stochastic Flags (available on predict, summarize, sentence, paragraph, essay, ask):
+  --stochastic                  Enable synonym-based randomization of output
+  --probability      Replacement rate 0.0 - 1.0 (default: 0.5)
 
 Options:
   -h, --help     Print help
@@ -434,6 +439,8 @@ lmm predict --text "Wise AI built the first LMM" --window 10 --predict-length 80
 | `-p`, `--predict-length` | `16`                              | Approximate character budget for continuation    |
 | `--iterations`           | `80`                              | GP evolution iterations for the prediction model |
 | `--depth`                | `4`                               | Maximum expression tree depth                    |
+| `--stochastic`           | `false`                           | Enable synonym-based output randomization        |
+| `--probability`          | `0.5`                             | Word replacement rate (0.0 = none, 1.0 = all)    |
 
 ### 10. `summarize`: Key Sentence Extraction
 
@@ -460,13 +467,18 @@ lmm summarize --text "The ancient Egyptians built the pyramids using advanced ma
 | ------------------- | ------- | ---------------------------------- |
 | `-t`, `--text`      | `...`   | Input text to summarize            |
 | `-n`, `--sentences` | `2`     | Number of key sentences to extract |
+| `--stochastic`      | `false` | Enable synonym-based randomization |
+| `--probability`     | `0.5`   | Word replacement rate (0.0 - 1.0)  |
 
 ### 11. `sentence`: Single Sentence Generation
 
-Generates a single, structurally elegant sentence inspired by a seed text, using rotating Subject-Verb-Object (SVO) sequence patterns parsed from math tones.
+Generates a single, structurally elegant sentence. Add `--stochastic` to randomize word choices on each run - the mathematical structure stays fixed while synonyms vary.
 
 ```sh
 lmm sentence --text "Mathematics is the language of the universe"
+
+# With stochastic: different output every time
+lmm sentence --text "Mathematics is the language of the universe" --stochastic
 ```
 
 ```sh
@@ -478,7 +490,19 @@ lmm sentence --text "Mathematics is the language of the universe"
 
 -- Generated Sentence ------------------------
   Analysis enables the dynamic meaning of the universe.
+
+# --stochastic run 1:
+  Cognition enables the dynamic significance of the world.
+
+# --stochastic run 2:
+  Purplish facilitates the dynamic meaning of the world.
 ```
+
+| Flag            | Default | Description                                       |
+| --------------- | ------- | ------------------------------------------------- |
+| `-t`, `--text`  | `...`   | Seed topic                                        |
+| `--stochastic`  | `false` | Randomize word synonyms each run                  |
+| `--probability` | `0.5`   | Fraction of eligible words to replace (0.0 - 1.0) |
 
 ### 12. `paragraph`: Cohesive Paragraph Generation
 
@@ -501,10 +525,12 @@ lmm paragraph --text "Equations reveal hidden truths about nature" --sentences 6
   Simulation manifests the continuous symmetry of the truths. The symmetric wavelength connects infinity. Entropy remains the invariant truths underlying knowledge. The entropy of truths connects infinity. In essence, the symmetric integration encodes boundaries. Dimension describes precise reality beneath truths.
 ```
 
-| Flag                | Default | Description                          |
-| ------------------- | ------- | ------------------------------------ |
-| `-t`, `--text`      | `...`   | Seed topic for paragraph generation  |
-| `-n`, `--sentences` | `4`     | Number of sentences in the paragraph |
+| Flag                | Default | Description                                       |
+| ------------------- | ------- | ------------------------------------------------- |
+| `-t`, `--text`      | `...`   | Seed topic for paragraph generation               |
+| `-n`, `--sentences` | `4`     | Number of sentences in the paragraph              |
+| `--stochastic`      | `false` | Randomize word synonyms each run                  |
+| `--probability`     | `0.5`   | Fraction of eligible words to replace (0.0 - 1.0) |
 
 ### 13. `essay`: Full Essay Blueprint
 
@@ -548,11 +574,13 @@ lmm essay --text 'Symmetry and the deeper patterns of physics' --paragraphs 2 --
   Gradient unveils the invariant limits of the symmetry. The invariant computation compresses balance. Divergence is the bounded symmetry of identity. The pattern of symmetry defines matter. Fundamentally, the continuous gradient generates truth. Logic determines axiomatic harmony across symmetry. Recursion determines the axiomatic infinity of the symmetry. The structural entropy illuminates infinity. Entropy are the probabilistic symmetry beneath space. The dimension of symmetry expresses reality. Moreover, the deterministic frequency defines existence. Frequency connects abstract perception of symmetry. Structure encodes the abstract chaos of the symmetry. The elegant integration encodes existence. Integration are the dynamic symmetry within meaning.
 ```
 
-| Flag                 | Default | Description                           |
-| -------------------- | ------- | ------------------------------------- |
-| `-t`, `--text`       | `...`   | Topic or title seed for the essay     |
-| `-n`, `--paragraphs` | `2`     | Number of body paragraphs to generate |
-| `-s`, `--sentences`  | `3`     | Number of sentences per paragraph     |
+| Flag                 | Default | Description                                       |
+| -------------------- | ------- | ------------------------------------------------- |
+| `-t`, `--text`       | `...`   | Topic or title seed for the essay                 |
+| `-n`, `--paragraphs` | `2`     | Number of body paragraphs to generate             |
+| `-s`, `--sentences`  | `3`     | Number of sentences per paragraph                 |
+| `--stochastic`       | `false` | Randomize word synonyms each run                  |
+| `--probability`      | `0.5`   | Fraction of eligible words to replace (0.0 - 1.0) |
 
 ### 14. `ask`: Internet-Aware Knowledge Synthesis _(requires `net` feature)_
 
@@ -601,14 +629,16 @@ URL: https://duckduckgo.com/c/Multi-paradigm_programming_languages?kp=%2D2
 > [!NOTE]
 > The `ask` command requires building with `--features cli,net`. No API key is needed.
 
-| Flag                | Default  | Description                                    |
-| ------------------- | -------- | ---------------------------------------------- |
-| `-p`, `--prompt`    | required | The question or search query                   |
-| `-l`, `--limit`     | `5`      | Maximum number of search results to fetch      |
-| `-n`, `--sentences` | `3`      | Number of key sentences to extract             |
-| `--region`          | `wt-wt`  | DuckDuckGo region code (e.g. `us-en`, `uk-en`) |
-| `--iterations`      | `40`     | GP scoring iterations                          |
-| `--depth`           | `3`      | Maximum GP expression depth                    |
+| Flag                | Default  | Description                                       |
+| ------------------- | -------- | ------------------------------------------------- |
+| `-p`, `--prompt`    | required | The question or search query                      |
+| `-l`, `--limit`     | `5`      | Maximum number of search results to fetch         |
+| `-n`, `--sentences` | `3`      | Number of key sentences to extract                |
+| `--region`          | `wt-wt`  | DuckDuckGo region code (e.g. `us-en`, `uk-en`)    |
+| `--iterations`      | `40`     | GP scoring iterations                             |
+| `--depth`           | `3`      | Maximum GP expression depth                       |
+| `--stochastic`      | `false`  | Randomize word synonyms in the answer             |
+| `--probability`     | `0.5`    | Fraction of eligible words to replace (0.0 - 1.0) |
 
 ### 15. `imagen`: Spectral Field Synthesis Image Generation
 
@@ -685,6 +715,31 @@ flowchart TD
 
     Score -->|Lowest Score| W["Select Best Word from Vocab"]
     W -->|Update Recency| Out
+```
+
+### Stochastic Synonym Enhancement
+
+When `--stochastic` is enabled, the deterministic output is piped through the `StochasticEnhancer` layer, which draws from two synonym sources:
+
+```mermaid
+flowchart TD
+    T["Deterministic Text Output\n(sentence / paragraph / essay / summary)"] --> TOK["Tokenizer\n(split words, strip punctuation)"]
+
+    TOK --> STW{Stop Word?}
+    STW -- Yes --> KEEP["Keep Original Word"]
+    STW -- No --> PROB{"Random(0,1) < probability?"}
+
+    PROB -- No --> KEEP
+    PROB -- Yes --> CUR["Curated Synonym Table\n(100+ scientific / mathematical terms)"]
+
+    CUR -- Found --> SYN["Pick Random Synonym"]
+    CUR -- Not Found --> WL["System Dictionary Fallback\n(/usr/share/dict/words)\ngrouped by word length"]
+    WL -- Found --> SYN
+    WL -- Not Found --> KEEP
+
+    SYN --> CASE["Restore Capitalization\n& Punctuation"]
+    KEEP --> CASE
+    CASE --> OUT["Stochastic Output\n(unique each run)"]
 ```
 
 ### Spectral Field Synthesis Image Generation

--- a/bin/lmm.js
+++ b/bin/lmm.js
@@ -1,3 +1,4 @@
 #!/usr/bin/env node
-import { runCli } from "../index.js";
+// @ts-ignore
+const { runCli } = require("../index.js");
 runCli(process.argv.slice(1));

--- a/package.json
+++ b/package.json
@@ -54,6 +54,5 @@
   },
   "engines": {
     "node": ">= 22"
-  },
-  "optionalDependencies": {}
+  }
 }

--- a/src/app.rs
+++ b/src/app.rs
@@ -161,6 +161,15 @@ fn divider(label: &str) {
 }
 
 #[cfg(feature = "cli")]
+fn maybe_enhance(text: &str, stochastic: bool, probability: f64) -> String {
+    if stochastic {
+        crate::stochastic::StochasticEnhancer::new(probability).enhance(text)
+    } else {
+        text.to_string()
+    }
+}
+
+#[cfg(feature = "cli")]
 pub async fn run_cli_entry(args: Vec<String>) -> anyhow::Result<()> {
     setup_logging()?;
 
@@ -381,6 +390,8 @@ pub async fn run_cli_entry(args: Vec<String>) -> anyhow::Result<()> {
             iterations,
             depth,
             dictionary,
+            stochastic,
+            probability,
         } => {
             banner("Predict · Symbolic Continuation", "🔮");
             let source = load_source(&input, text)?;
@@ -399,7 +410,11 @@ pub async fn run_cli_entry(args: Vec<String>) -> anyhow::Result<()> {
             info!("  📈 Trajectory: {}", result.trajectory_equation);
             info!("  🎵 Rhythm    : {}", result.rhythm_equation);
             divider("Continuation");
-            info!("  {}{}", source, result.continuation);
+            info!(
+                "  {}{}",
+                source,
+                maybe_enhance(&result.continuation, stochastic, probability)
+            );
         }
 
         Summarize {
@@ -408,6 +423,8 @@ pub async fn run_cli_entry(args: Vec<String>) -> anyhow::Result<()> {
             sentences,
             iterations,
             depth,
+            stochastic,
+            probability,
         } => {
             banner("Summarize · Key Sentence Extraction", "✂️");
             let source = load_source(&input, text)?;
@@ -421,7 +438,11 @@ pub async fn run_cli_entry(args: Vec<String>) -> anyhow::Result<()> {
                 Ok(summary) => {
                     divider("Summary");
                     for (i, sentence) in summary.iter().enumerate() {
-                        info!("  {}. {}", i + 1, sentence);
+                        info!(
+                            "  {}. {}",
+                            i + 1,
+                            maybe_enhance(sentence, stochastic, probability)
+                        );
                     }
                 }
                 Err(e) => {
@@ -435,6 +456,8 @@ pub async fn run_cli_entry(args: Vec<String>) -> anyhow::Result<()> {
             text,
             iterations,
             depth,
+            stochastic,
+            probability,
         } => {
             banner("Sentence · Single Sentence Generation", "✍️");
             let source = load_source(&input, text)?;
@@ -443,7 +466,7 @@ pub async fn run_cli_entry(args: Vec<String>) -> anyhow::Result<()> {
             match sentence_gen.generate(&source) {
                 Ok(sentence) => {
                     divider("Generated Sentence");
-                    info!("  {}", sentence);
+                    info!("  {}", maybe_enhance(&sentence, stochastic, probability));
                 }
                 Err(e) => {
                     error!("  ❌ Generation failed: {}", e);
@@ -457,6 +480,8 @@ pub async fn run_cli_entry(args: Vec<String>) -> anyhow::Result<()> {
             sentences,
             iterations,
             depth,
+            stochastic,
+            probability,
         } => {
             banner("Paragraph · Generate a Paragraph", "📄");
             let source = load_source(&input, text)?;
@@ -467,7 +492,7 @@ pub async fn run_cli_entry(args: Vec<String>) -> anyhow::Result<()> {
                 Ok(paragraph) => {
                     divider("Generated Paragraph");
                     info!("");
-                    info!("  {}", paragraph);
+                    info!("  {}", maybe_enhance(&paragraph, stochastic, probability));
                 }
                 Err(e) => {
                     error!("  ❌ Generation failed: {}", e);
@@ -482,6 +507,8 @@ pub async fn run_cli_entry(args: Vec<String>) -> anyhow::Result<()> {
             sentences,
             iterations,
             depth,
+            stochastic,
+            probability,
         } => {
             banner("Essay · Generate a Full Essay", "📖");
             let source = load_source(&input, text)?;
@@ -509,7 +536,7 @@ pub async fn run_cli_entry(args: Vec<String>) -> anyhow::Result<()> {
                         };
                         divider(&label);
                         info!("");
-                        info!("  {}", para);
+                        info!("  {}", maybe_enhance(para, stochastic, probability));
                         info!("");
                     }
                 }
@@ -527,6 +554,8 @@ pub async fn run_cli_entry(args: Vec<String>) -> anyhow::Result<()> {
             region,
             iterations,
             depth,
+            stochastic,
+            probability,
         } => {
             banner("Ask · Internet-Aware Knowledge Synthesis", "🌐");
             info!("  ❓ Prompt : {:?}", prompt);
@@ -564,7 +593,7 @@ pub async fn run_cli_entry(args: Vec<String>) -> anyhow::Result<()> {
                 match summarizer.summarize_with_query(&final_corpus, &prompt) {
                     Ok(summary) => {
                         for sentence in &summary {
-                            info!("  {}", sentence);
+                            info!("  {}", maybe_enhance(sentence, stochastic, probability));
                         }
                     }
                     Err(e) => error!("  ❌ Summarization failed: {}", e),

--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -125,6 +125,10 @@ pub enum Commands {
         depth: usize,
         #[arg(long)]
         dictionary: Option<String>,
+        #[arg(long, default_value_t = false)]
+        stochastic: bool,
+        #[arg(long, default_value_t = 0.5)]
+        probability: f64,
     },
     #[command(about = "Extract key meaning via GP scoring")]
     Summarize {
@@ -142,6 +146,10 @@ pub enum Commands {
         iterations: usize,
         #[arg(long, default_value_t = 3)]
         depth: usize,
+        #[arg(long, default_value_t = false)]
+        stochastic: bool,
+        #[arg(long, default_value_t = 0.5)]
+        probability: f64,
     },
     #[command(about = "Generate a single structural sentence")]
     Sentence {
@@ -153,6 +161,10 @@ pub enum Commands {
         iterations: usize,
         #[arg(long, default_value_t = 3)]
         depth: usize,
+        #[arg(long, default_value_t = false)]
+        stochastic: bool,
+        #[arg(long, default_value_t = 0.5)]
+        probability: f64,
     },
     #[command(about = "Generate a cohesive paragraph from a seed")]
     Paragraph {
@@ -170,6 +182,10 @@ pub enum Commands {
         iterations: usize,
         #[arg(long, default_value_t = 3)]
         depth: usize,
+        #[arg(long, default_value_t = false)]
+        stochastic: bool,
+        #[arg(long, default_value_t = 0.5)]
+        probability: f64,
     },
     #[command(about = "Structure a full essay with intro and conclusion")]
     Essay {
@@ -189,6 +205,10 @@ pub enum Commands {
         iterations: usize,
         #[arg(long, default_value_t = 3)]
         depth: usize,
+        #[arg(long, default_value_t = false)]
+        stochastic: bool,
+        #[arg(long, default_value_t = 0.5)]
+        probability: f64,
     },
     #[cfg(feature = "net")]
     #[command(about = "Ask a question and get an equation-scored answer from the web")]
@@ -205,6 +225,10 @@ pub enum Commands {
         iterations: usize,
         #[arg(long, default_value_t = 3)]
         depth: usize,
+        #[arg(long, default_value_t = false)]
+        stochastic: bool,
+        #[arg(long, default_value_t = 0.5)]
+        probability: f64,
     },
     #[command(about = "Generate an image from text via Spectral Field Synthesis")]
     Imagen {

--- a/src/imagen.rs
+++ b/src/imagen.rs
@@ -10,6 +10,16 @@ const FNV_OFFSET_BASIS: u64 = 14695981039346656037;
 const FNV_PRIME: u64 = 1099511628211;
 const PROMPT_INDEX_MULTIPLIER: u64 = 31;
 
+const WAVE_BAND_STRIDE: u64 = 997;
+const WAVE_COMPONENT_STRIDE: u64 = 31337;
+const MIN_WAVE_COMPONENTS: usize = 3;
+const MAX_WAVE_COMPONENTS: usize = 32;
+const FRACTAL_MAX_ITERATIONS: u32 = 32;
+const FRACTAL_ESCAPE_RADIUS_SQ: f64 = 4.0;
+const STYLE_SIGMA_SEED_OFFSET: u64 = 99;
+const FRACTAL_C_REAL_SEED_OFFSET: u64 = 77;
+const FRACTAL_C_IMAG_SEED_OFFSET: u64 = 78;
+
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum StyleMode {
     Wave,
@@ -136,8 +146,8 @@ struct WaveComponent {
 impl WaveComponent {
     fn from_seed(seed: u64, band: u64, component: u64) -> Self {
         let s = seed
-            .wrapping_add(band * 997)
-            .wrapping_add(component * 31337);
+            .wrapping_add(band * WAVE_BAND_STRIDE)
+            .wrapping_add(component * WAVE_COMPONENT_STRIDE);
         let amplitude = lcg_unit(s) * 0.6 + 0.1;
         let freq_x = lcg_unit(s.wrapping_add(1)) * 5.0 + 0.5;
         let freq_y = lcg_unit(s.wrapping_add(2)) * 5.0 + 0.5;
@@ -166,7 +176,7 @@ fn apply_style(nx: f64, ny: f64, base: f64, style: StyleMode, seed: u64) -> f64 
     let cy = ny - 0.5;
     let r = (cx * cx + cy * cy).sqrt();
     let theta = cy.atan2(cx);
-    let sigma = lcg_unit(seed.wrapping_add(99)) * 0.3 + 0.2;
+    let sigma = lcg_unit(seed.wrapping_add(STYLE_SIGMA_SEED_OFFSET)) * 0.3 + 0.2;
 
     match style {
         StyleMode::Wave => base,
@@ -182,17 +192,17 @@ fn apply_style(nx: f64, ny: f64, base: f64, style: StyleMode, seed: u64) -> f64 
         StyleMode::Fractal => {
             let mut z_r = cx * 3.0 + base;
             let mut z_i = cy * 3.0;
-            let c_r = lcg_unit(seed.wrapping_add(77)) * 2.0 - 1.0;
-            let c_i = lcg_unit(seed.wrapping_add(78)) * 2.0 - 1.0;
-            let max_iter = 32u32;
+            let c_r = lcg_unit(seed.wrapping_add(FRACTAL_C_REAL_SEED_OFFSET)) * 2.0 - 1.0;
+            let c_i = lcg_unit(seed.wrapping_add(FRACTAL_C_IMAG_SEED_OFFSET)) * 2.0 - 1.0;
             let mut iter = 0u32;
-            while iter < max_iter && z_r * z_r + z_i * z_i < 4.0 {
+            while iter < FRACTAL_MAX_ITERATIONS && z_r * z_r + z_i * z_i < FRACTAL_ESCAPE_RADIUS_SQ
+            {
                 let tmp = z_r * z_r - z_i * z_i + c_r;
                 z_i = 2.0 * z_r * z_i + c_i;
                 z_r = tmp;
                 iter += 1;
             }
-            iter as f64 / max_iter as f64
+            iter as f64 / FRACTAL_MAX_ITERATIONS as f64
         }
         StyleMode::Flow => {
             let stream_x = (TAU * ny * 2.0 + base).sin();
@@ -247,7 +257,9 @@ pub fn render(params: &ImagenParams) -> Result<String> {
         _ => Palette::from_seed(seed),
     };
 
-    let n = params.components.clamp(3, 32);
+    let n = params
+        .components
+        .clamp(MIN_WAVE_COMPONENTS, MAX_WAVE_COMPONENTS);
     let red_waves: Vec<WaveComponent> = (0..n)
         .map(|k| WaveComponent::from_seed(seed, 0, k as u64))
         .collect();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,6 +22,7 @@ pub mod physics;
 pub mod predict;
 pub mod prelude;
 pub mod simulation;
+pub mod stochastic;
 pub mod symbolic;
 pub mod tensor;
 pub mod text;

--- a/src/stochastic.rs
+++ b/src/stochastic.rs
@@ -1,0 +1,695 @@
+use rand::{Rng, RngExt};
+use std::collections::HashMap;
+use std::fs;
+
+static SYSTEM_DICT_PATHS: &[&str] = &[
+    "/usr/share/dict/american-english",
+    "/usr/share/dict/english",
+    "/usr/share/dict/words",
+    "/usr/dict/words",
+];
+const DEFAULT_REPLACEMENT_PROBABILITY: f64 = 0.5;
+const WORDLIST_MIN_WORD_LEN: usize = 5;
+const WORDLIST_MAX_WORD_LEN: usize = 14;
+
+const STOP_WORDS: &[&str] = &[
+    "a", "an", "the", "and", "or", "but", "in", "on", "at", "to", "for", "of", "with", "by", "is",
+    "are", "was", "were", "be", "been", "have", "has", "had", "do", "does", "did", "will", "would",
+    "could", "should", "may", "might", "shall", "its", "it", "this", "that", "these", "those",
+    "not", "no", "nor", "so", "yet", "both", "also", "as", "if", "than", "then", "from", "into",
+    "through", "during", "before", "after", "above", "below", "between", "each", "every", "any",
+];
+
+fn build_curated_table() -> HashMap<String, Vec<String>> {
+    let mut m: HashMap<String, Vec<String>> = HashMap::new();
+
+    let entries: &[(&str, &[&str])] = &[
+        (
+            "enables",
+            &["allows", "permits", "empowers", "facilitates", "supports"],
+        ),
+        (
+            "represents",
+            &["embodies", "symbolizes", "denotes", "signifies", "captures"],
+        ),
+        (
+            "describes",
+            &["illustrates", "portrays", "articulates", "characterizes"],
+        ),
+        (
+            "manifests",
+            &["reveals", "expresses", "demonstrates", "exhibits"],
+        ),
+        (
+            "connects",
+            &["links", "unifies", "bridges", "binds", "joins"],
+        ),
+        (
+            "encodes",
+            &["captures", "compresses", "maps", "stores", "embeds"],
+        ),
+        (
+            "defines",
+            &["specifies", "determines", "establishes", "delineates"],
+        ),
+        (
+            "produces",
+            &["generates", "yields", "creates", "constructs", "forms"],
+        ),
+        (
+            "transforms",
+            &["converts", "shifts", "alters", "reconfigures", "reshapes"],
+        ),
+        (
+            "reveals",
+            &["uncovers", "exposes", "discloses", "illuminates", "shows"],
+        ),
+        (
+            "governs",
+            &["controls", "regulates", "directs", "commands", "shapes"],
+        ),
+        (
+            "expresses",
+            &["articulates", "conveys", "communicates", "transmits"],
+        ),
+        (
+            "unveils",
+            &["discloses", "reveals", "exposes", "uncovers", "presents"],
+        ),
+        (
+            "illuminates",
+            &["clarifies", "enlightens", "elucidates", "reveals", "shows"],
+        ),
+        (
+            "shapes",
+            &["molds", "forms", "structures", "defines", "guides"],
+        ),
+        (
+            "compresses",
+            &["condenses", "distills", "reduces", "encapsulates"],
+        ),
+        (
+            "captures",
+            &["encompasses", "embodies", "encapsulates", "reflects"],
+        ),
+        (
+            "generates",
+            &["produces", "creates", "yields", "synthesizes", "builds"],
+        ),
+        (
+            "determines",
+            &["establishes", "dictates", "defines", "resolves", "fixes"],
+        ),
+        (
+            "remains",
+            &["persists", "endures", "abides", "continues", "stands"],
+        ),
+        (
+            "reflects",
+            &["embodies", "mirrors", "represents", "signifies", "echoes"],
+        ),
+        (
+            "underlies",
+            &["supports", "grounds", "anchors", "sustains", "informs"],
+        ),
+        (
+            "emerges",
+            &["arises", "surfaces", "appears", "originates", "unfolds"],
+        ),
+        (
+            "constrains",
+            &["limits", "bounds", "restricts", "confines", "regulates"],
+        ),
+        (
+            "encapsulates",
+            &["contains", "embodies", "summarizes", "condenses"],
+        ),
+        (
+            "preserves",
+            &["maintains", "sustains", "conserves", "upholds", "keeps"],
+        ),
+        (
+            "separates",
+            &["divides", "partitions", "distinguishes", "isolates"],
+        ),
+        (
+            "truth",
+            &["reality", "fact", "knowledge", "verity", "actuality"],
+        ),
+        (
+            "reality",
+            &["existence", "actuality", "world", "nature", "truth"],
+        ),
+        (
+            "knowledge",
+            &[
+                "understanding",
+                "wisdom",
+                "insight",
+                "cognition",
+                "learning",
+            ],
+        ),
+        (
+            "pattern",
+            &[
+                "structure",
+                "design",
+                "configuration",
+                "arrangement",
+                "form",
+            ],
+        ),
+        (
+            "structure",
+            &["framework", "organization", "architecture", "arrangement"],
+        ),
+        (
+            "symmetry",
+            &["balance", "harmony", "proportion", "regularity", "order"],
+        ),
+        (
+            "entropy",
+            &[
+                "disorder",
+                "chaos",
+                "uncertainty",
+                "complexity",
+                "randomness",
+            ],
+        ),
+        (
+            "energy",
+            &["power", "force", "dynamics", "vitality", "potential"],
+        ),
+        (
+            "complexity",
+            &["intricacy", "depth", "sophistication", "richness"],
+        ),
+        (
+            "harmony",
+            &["balance", "coherence", "unity", "symmetry", "accord"],
+        ),
+        (
+            "balance",
+            &["equilibrium", "harmony", "poise", "stability", "proportion"],
+        ),
+        (
+            "motion",
+            &["movement", "dynamics", "flow", "trajectory", "progression"],
+        ),
+        (
+            "order",
+            &["structure", "organization", "coherence", "arrangement"],
+        ),
+        (
+            "chaos",
+            &["disorder", "turbulence", "randomness", "entropy", "flux"],
+        ),
+        (
+            "dimension",
+            &["axis", "aspect", "realm", "domain", "magnitude"],
+        ),
+        (
+            "infinity",
+            &["boundlessness", "endlessness", "vastness", "eternity"],
+        ),
+        (
+            "perception",
+            &["awareness", "insight", "observation", "cognition", "sense"],
+        ),
+        (
+            "meaning",
+            &["significance", "substance", "essence", "purpose", "value"],
+        ),
+        (
+            "existence",
+            &["being", "reality", "presence", "life", "manifestation"],
+        ),
+        (
+            "universe",
+            &["cosmos", "world", "reality", "existence", "totality"],
+        ),
+        (
+            "mathematics",
+            &["algebra", "geometry", "calculus", "arithmetic", "analysis"],
+        ),
+        (
+            "equation",
+            &["formula", "expression", "relationship", "model", "identity"],
+        ),
+        (
+            "frequency",
+            &["resonance", "oscillation", "wavelength", "rhythm", "rate"],
+        ),
+        (
+            "resonance",
+            &["harmony", "vibration", "coherence", "synchrony", "accord"],
+        ),
+        (
+            "evolution",
+            &["transformation", "progression", "development", "dynamics"],
+        ),
+        (
+            "boundary",
+            &["limit", "threshold", "barrier", "edge", "frontier"],
+        ),
+        (
+            "trajectory",
+            &["path", "course", "orbit", "direction", "arc"],
+        ),
+        (
+            "causality",
+            &["determinism", "consequence", "mechanism", "logic", "reason"],
+        ),
+        (
+            "logic",
+            &[
+                "reasoning",
+                "rationality",
+                "inference",
+                "deduction",
+                "thought",
+            ],
+        ),
+        (
+            "force",
+            &["energy", "power", "influence", "dynamics", "pressure"],
+        ),
+        ("space", &["realm", "domain", "expanse", "field", "region"]),
+        (
+            "time",
+            &["moment", "epoch", "duration", "continuity", "period"],
+        ),
+        ("field", &["domain", "region", "space", "realm", "expanse"]),
+        (
+            "wave",
+            &["oscillation", "vibration", "ripple", "undulation", "pulse"],
+        ),
+        (
+            "signal",
+            &["indicator", "marker", "pattern", "trace", "message"],
+        ),
+        (
+            "computation",
+            &["calculation", "processing", "evaluation", "analysis"],
+        ),
+        (
+            "simulation",
+            &["modeling", "emulation", "representation", "approximation"],
+        ),
+        (
+            "prediction",
+            &["forecast", "projection", "estimation", "inference"],
+        ),
+        (
+            "discovery",
+            &[
+                "revelation",
+                "finding",
+                "insight",
+                "breakthrough",
+                "perception",
+            ],
+        ),
+        (
+            "foundation",
+            &["basis", "grounding", "core", "bedrock", "principle"],
+        ),
+        ("principle", &["law", "rule", "axiom", "tenet", "doctrine"]),
+        (
+            "intelligence",
+            &["cognition", "awareness", "reasoning", "understanding"],
+        ),
+        (
+            "consciousness",
+            &["awareness", "perception", "cognition", "sentience"],
+        ),
+        (
+            "mathematical",
+            &["symbolic", "geometric", "algebraic", "analytical", "formal"],
+        ),
+        (
+            "deterministic",
+            &["predictable", "systematic", "causal", "precise", "exact"],
+        ),
+        (
+            "probabilistic",
+            &[
+                "stochastic",
+                "statistical",
+                "uncertain",
+                "random",
+                "variable",
+            ],
+        ),
+        (
+            "infinite",
+            &["boundless", "endless", "vast", "immeasurable", "limitless"],
+        ),
+        (
+            "fundamental",
+            &["essential", "core", "primary", "foundational", "elemental"],
+        ),
+        (
+            "dynamic",
+            &["evolving", "fluid", "active", "continuous", "adaptive"],
+        ),
+        (
+            "abstract",
+            &["symbolic", "conceptual", "theoretical", "pure", "ideal"],
+        ),
+        (
+            "continuous",
+            &["unbroken", "flowing", "perpetual", "sustained", "smooth"],
+        ),
+        (
+            "discrete",
+            &["distinct", "separate", "finite", "quantized", "isolated"],
+        ),
+        (
+            "invariant",
+            &["constant", "stable", "fixed", "unchanging", "conserved"],
+        ),
+        (
+            "coherent",
+            &[
+                "unified",
+                "consistent",
+                "structured",
+                "harmonious",
+                "ordered",
+            ],
+        ),
+        (
+            "structural",
+            &["architectural", "organizational", "systematic", "formal"],
+        ),
+        (
+            "axiomatic",
+            &["foundational", "self-evident", "primary", "elemental"],
+        ),
+        (
+            "bounded",
+            &[
+                "finite",
+                "constrained",
+                "limited",
+                "contained",
+                "restricted",
+            ],
+        ),
+        (
+            "symmetric",
+            &["balanced", "regular", "uniform", "proportional", "equal"],
+        ),
+        (
+            "elegant",
+            &["refined", "sophisticated", "beautiful", "graceful", "pure"],
+        ),
+        (
+            "precise",
+            &["exact", "accurate", "rigorous", "meticulous", "definite"],
+        ),
+        (
+            "universal",
+            &["general", "global", "absolute", "total", "pervasive"],
+        ),
+        (
+            "recursive",
+            &["iterative", "self-referential", "repetitive", "cyclic"],
+        ),
+        (
+            "emergent",
+            &[
+                "arising",
+                "evolving",
+                "developing",
+                "unfolding",
+                "appearing",
+            ],
+        ),
+        (
+            "complex",
+            &["intricate", "sophisticated", "multifaceted", "rich", "deep"],
+        ),
+        (
+            "simple",
+            &["elementary", "basic", "pure", "direct", "minimal"],
+        ),
+        (
+            "ancient",
+            &[
+                "primordial",
+                "prehistoric",
+                "archaic",
+                "classical",
+                "timeless",
+            ],
+        ),
+        (
+            "sacred",
+            &["divine", "revered", "hallowed", "eternal", "transcendent"],
+        ),
+        (
+            "cosmic",
+            &["universal", "celestial", "infinite", "vast", "transcendent"],
+        ),
+        (
+            "hidden",
+            &["concealed", "latent", "underlying", "subtle", "implicit"],
+        ),
+        (
+            "deeper",
+            &["profound", "fundamental", "underlying", "essential", "core"],
+        ),
+        (
+            "new",
+            &["novel", "emerging", "fresh", "modern", "innovative"],
+        ),
+        (
+            "pure",
+            &[
+                "exact",
+                "unadulterated",
+                "precise",
+                "fundamental",
+                "essential",
+            ],
+        ),
+        (
+            "true",
+            &["genuine", "authentic", "real", "valid", "accurate"],
+        ),
+        (
+            "great",
+            &[
+                "profound",
+                "vast",
+                "significant",
+                "remarkable",
+                "extraordinary",
+            ],
+        ),
+        (
+            "vast",
+            &["immense", "expansive", "boundless", "infinite", "enormous"],
+        ),
+        (
+            "known",
+            &[
+                "established",
+                "recognized",
+                "understood",
+                "observed",
+                "verified",
+            ],
+        ),
+        (
+            "seen",
+            &["observed", "perceived", "recognized", "witnessed", "noted"],
+        ),
+        (
+            "made",
+            &["constructed", "formed", "created", "built", "composed"],
+        ),
+        (
+            "called",
+            &["named", "termed", "labeled", "designated", "referred"],
+        ),
+    ];
+
+    for (word, synonyms) in entries {
+        m.insert(
+            word.to_string(),
+            synonyms.iter().map(|s| s.to_string()).collect(),
+        );
+    }
+
+    m
+}
+
+fn load_wordlist_by_length() -> HashMap<usize, Vec<String>> {
+    let mut by_length: HashMap<usize, Vec<String>> = HashMap::new();
+    for path in SYSTEM_DICT_PATHS {
+        if let Ok(content) = fs::read_to_string(path) {
+            for word in content.lines() {
+                let w = word.trim().to_lowercase();
+                if w.len() >= WORDLIST_MIN_WORD_LEN
+                    && w.len() <= WORDLIST_MAX_WORD_LEN
+                    && w.chars().all(|c| c.is_ascii_alphabetic())
+                {
+                    by_length.entry(w.len()).or_default().push(w);
+                }
+            }
+            break;
+        }
+    }
+    by_length
+}
+
+pub struct SynonymBank {
+    curated: HashMap<String, Vec<String>>,
+    by_length: HashMap<usize, Vec<String>>,
+}
+
+impl SynonymBank {
+    pub fn new() -> Self {
+        Self {
+            curated: build_curated_table(),
+            by_length: load_wordlist_by_length(),
+        }
+    }
+
+    pub fn candidate<R: Rng>(&self, word: &str, rng: &mut R) -> Option<String> {
+        let lower = word.to_lowercase();
+        if let Some(syns) = self.curated.get(&lower) {
+            let idx = rng.random_range(0..syns.len());
+            return Some(syns[idx].clone());
+        }
+        if let Some(bucket) = self.by_length.get(&lower.len()) {
+            let candidates: Vec<&String> = bucket.iter().filter(|w| w.as_str() != lower).collect();
+            if !candidates.is_empty() {
+                let idx = rng.random_range(0..candidates.len());
+                return Some(candidates[idx].clone());
+            }
+        }
+        None
+    }
+
+    pub fn curated_count(&self) -> usize {
+        self.curated.len()
+    }
+
+    pub fn wordlist_len(&self) -> usize {
+        self.by_length.values().map(|v| v.len()).sum()
+    }
+}
+
+impl Default for SynonymBank {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+pub struct StochasticEnhancer {
+    bank: SynonymBank,
+    probability: f64,
+}
+
+impl StochasticEnhancer {
+    pub fn new(probability: f64) -> Self {
+        Self {
+            bank: SynonymBank::new(),
+            probability: probability.clamp(0.0, 1.0),
+        }
+    }
+
+    pub fn with_default_probability() -> Self {
+        Self::new(DEFAULT_REPLACEMENT_PROBABILITY)
+    }
+
+    pub fn enhance(&self, text: &str) -> String {
+        let mut rng = rand::rng();
+        text.split('\n')
+            .map(|line| self.enhance_line(line, &mut rng))
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+
+    fn enhance_line<R: Rng>(&self, line: &str, rng: &mut R) -> String {
+        let words = line.split_whitespace().peekable();
+        let mut result: Vec<String> = Vec::new();
+        let mut is_first = true;
+
+        for raw in words {
+            let (prefix, core, suffix) = split_token(raw);
+            let lower = core.to_lowercase();
+            let is_stop = STOP_WORDS.contains(&lower.as_str());
+            let was_capitalized = core
+                .chars()
+                .next()
+                .map(|c| c.is_uppercase())
+                .unwrap_or(false);
+            let was_all_caps = core.chars().all(|c| c.is_uppercase());
+
+            let replacement = if !is_stop && !core.is_empty() && rng.random_bool(self.probability) {
+                match self.bank.candidate(&lower, rng) {
+                    Some(syn) => {
+                        if was_all_caps {
+                            syn.to_uppercase()
+                        } else if was_capitalized || is_first {
+                            capitalize(&syn)
+                        } else {
+                            syn
+                        }
+                    }
+                    None => core.to_string(),
+                }
+            } else {
+                core.to_string()
+            };
+
+            result.push(format!("{}{}{}", prefix, replacement, suffix));
+            is_first = false;
+        }
+
+        result.join(" ")
+    }
+}
+
+fn split_token(raw: &str) -> (&str, &str, &str) {
+    let prefix_end = raw.find(|c: char| c.is_alphabetic()).unwrap_or(raw.len());
+    let content_start = prefix_end;
+
+    if content_start >= raw.len() {
+        return ("", raw, "");
+    }
+
+    let suffix_start = raw[content_start..]
+        .rfind(|c: char| c.is_alphabetic())
+        .map(|i| {
+            content_start
+                + i
+                + raw[content_start + i..]
+                    .chars()
+                    .next()
+                    .map(|ch| ch.len_utf8())
+                    .unwrap_or(1)
+        })
+        .unwrap_or(raw.len());
+
+    (
+        &raw[..content_start],
+        &raw[content_start..suffix_start],
+        &raw[suffix_start..],
+    )
+}
+
+fn capitalize(s: &str) -> String {
+    let mut chars = s.chars();
+    match chars.next() {
+        None => String::new(),
+        Some(first) => first.to_uppercase().collect::<String>() + chars.as_str(),
+    }
+}

--- a/tests/stochastic.rs
+++ b/tests/stochastic.rs
@@ -1,0 +1,134 @@
+use lmm::stochastic::{StochasticEnhancer, SynonymBank};
+
+#[test]
+fn synonym_bank_has_curated_entries() {
+    let bank = SynonymBank::new();
+    assert!(bank.curated_count() > 50);
+}
+
+#[test]
+fn synonym_bank_has_wordlist() {
+    let bank = SynonymBank::new();
+    let has_dictionary = [
+        "/usr/share/dict/american-english",
+        "/usr/share/dict/english",
+        "/usr/share/dict/words",
+        "/usr/dict/words",
+    ]
+    .iter()
+    .any(|p| std::path::Path::new(p).exists());
+
+    if has_dictionary {
+        assert!(bank.wordlist_len() > 0);
+    } else {
+        assert_eq!(bank.wordlist_len(), 0);
+    }
+}
+
+#[test]
+fn enhancer_changes_text_when_probability_one() {
+    let enhancer = StochasticEnhancer::new(1.0);
+    let input = "Mathematics enables the representation of reality through elegant equations.";
+    let run1 = enhancer.enhance(input);
+    let run2 = enhancer.enhance(input);
+    assert_ne!(run1, run2, "Two runs at probability=1.0 should differ");
+}
+
+#[test]
+fn enhancer_preserves_text_when_probability_zero() {
+    let enhancer = StochasticEnhancer::new(0.0);
+    let input = "The ancient Egyptians built the pyramids using mathematical knowledge.";
+    let result = enhancer.enhance(input);
+    assert_eq!(result, input);
+}
+
+#[test]
+fn enhancer_preserves_sentence_count() {
+    let enhancer = StochasticEnhancer::new(0.8);
+    let input =
+        "Equations govern reality. Mathematics reveals truth. Physics shapes our understanding.";
+    let result = enhancer.enhance(input);
+    let input_sentences = input.matches('.').count();
+    let output_sentences = result.matches('.').count();
+    assert_eq!(input_sentences, output_sentences);
+}
+
+#[test]
+fn enhancer_preserves_stop_words() {
+    let enhancer = StochasticEnhancer::new(1.0);
+    let input = "The equations and the patterns are in the universe.";
+    let result = enhancer.enhance(input);
+    assert!(
+        result.to_lowercase().contains("the"),
+        "Stop word 'the' should be preserved"
+    );
+}
+
+#[test]
+fn enhancer_preserves_trailing_punctuation() {
+    let enhancer = StochasticEnhancer::new(1.0);
+    let input = "Mathematics enables knowledge.";
+    for _ in 0..5 {
+        let result = enhancer.enhance(input);
+        assert!(
+            result.ends_with('.'),
+            "Result must end with period, got: {}",
+            result
+        );
+    }
+}
+
+#[test]
+fn enhancer_preserves_capitalization_on_first_word() {
+    let enhancer = StochasticEnhancer::new(1.0);
+    let input = "Entropy governs the structure of complexity.";
+    for _ in 0..5 {
+        let result = enhancer.enhance(input);
+        let first_char = result.chars().next().unwrap();
+        assert!(
+            first_char.is_uppercase(),
+            "First char must be uppercase, got: {}",
+            result
+        );
+    }
+}
+
+#[test]
+fn enhancer_produces_non_empty_output() {
+    let enhancer = StochasticEnhancer::new(0.5);
+    let input = "The mathematical structure of the universe encodes reality.";
+    let result = enhancer.enhance(input);
+    assert!(!result.is_empty());
+    assert!(result.split_whitespace().count() > 3);
+}
+
+#[test]
+fn multiple_runs_all_differ() {
+    let enhancer = StochasticEnhancer::new(0.7);
+    let input = "Mathematics enables the representation of reality. Equations reveal the structure of knowledge. Entropy governs the evolution of complexity.";
+    let runs: Vec<String> = (0..5).map(|_| enhancer.enhance(input)).collect();
+    let unique: std::collections::HashSet<&String> = runs.iter().collect();
+    assert!(unique.len() >= 2, "At least 2 of 5 runs should be distinct");
+}
+
+#[test]
+fn enhancer_with_curated_word_replaces_known_synonyms() {
+    let enhancer = StochasticEnhancer::new(1.0);
+    let input = "Mathematics represents truth.";
+    let mut found_synonym = false;
+    let math_synonyms = ["algebra", "geometry", "calculus", "arithmetic", "analysis"];
+    let truth_synonyms = ["reality", "fact", "knowledge", "verity", "actuality"];
+    for _ in 0..20 {
+        let result = enhancer.enhance(input).to_lowercase();
+        if math_synonyms.iter().any(|s| result.contains(s))
+            || truth_synonyms.iter().any(|s| result.contains(s))
+        {
+            found_synonym = true;
+            break;
+        }
+    }
+    assert!(
+        found_synonym,
+        "At least one curated synonym should appear in 20 runs"
+    );
+}


### PR DESCRIPTION
Added a new global stochastic option to all text gen funcs:


<img width="881" height="446" alt="Screenshot from 2026-04-17 23-45-37" src="https://github.com/user-attachments/assets/115d6bc7-3ef1-4e5b-82ca-1287428772e9" />


<img width="994" height="562" alt="Screenshot from 2026-04-17 23-46-25" src="https://github.com/user-attachments/assets/fce49617-e143-41ce-8aa0-dbc9fa05a2b7" />


Ain't no way you can convince me that a neural network serves any purpose in society.

<img width="498" height="489" alt="Screenshot from 2026-04-17 23-55-38" src="https://github.com/user-attachments/assets/8fe76acb-e498-461d-916a-00d0f80ed526" />